### PR TITLE
Lookup enclosing module for types

### DIFF
--- a/src/mge/script/module.cpp
+++ b/src/mge/script/module.cpp
@@ -25,11 +25,19 @@ namespace mge::script {
 
     module::module(const module_details_ref& details)
         : m_details(details)
-    {}
+    {
+        if (m_details == nullptr) {
+            MGE_THROW(illegal_state) << "Invalid module reference";
+        }
+    }
 
     module::module(module_details_ref&& details)
         : m_details(std::move(details))
-    {}
+    {
+        if (m_details == nullptr) {
+            MGE_THROW(illegal_state) << "Invalid module reference";
+        }
+    }
 
     module::~module() {}
 

--- a/src/mge/script/type_details.cpp
+++ b/src/mge/script/type_details.cpp
@@ -165,6 +165,19 @@ namespace mge::script {
         m_enclosing_type = t;
     }
 
+    module_details_ref type_details::enclosing_module() const
+    {
+        auto ret = m_module.lock();
+        if (!ret) {
+            if (!m_enclosing_type) {
+                MGE_THROW(mge::illegal_state)
+                    << "Type '" << name() << "' has no module or parent type";
+            }
+            return m_enclosing_type->enclosing_module();
+        }
+        return ret;
+    }
+
     type_details_ref type_details::get(const std::type_index& ti)
     {
         return s_type_dictionary->get(ti);
@@ -239,11 +252,10 @@ namespace mge::script {
         }
         v.start(self);
 
-        /* no recursive types yet
         for (const auto& [ti, details] : m_types) {
             details->apply(details, v);
         }
-        */
+
         for (const auto& f : m_fields) {
             v.field(f.name, f.type, f.getter, f.setter);
         }

--- a/src/mge/script/type_details.hpp
+++ b/src/mge/script/type_details.hpp
@@ -37,6 +37,7 @@ namespace mge::script {
 
         void set_module(const module_details_ref& m);
         void set_enclosing_type(const type_details_ref& t);
+        module_details_ref enclosing_module() const;
 
         /**
          * @brief Lookup details by type index.

--- a/src/modules/python/python_type.cpp
+++ b/src/modules/python/python_type.cpp
@@ -164,15 +164,8 @@ namespace mge::python {
 
     void python_type::materialize_enum_type() const
     {
-        auto m = m_context.get_module(m_type->module().lock());
-
-        if (!m) {
-            MGE_THROW(mge::illegal_state)
-                << "Module '" << m_type->module().lock()->name()
-                << "' not found";
-        }
-
-        PyTypeObject* base = &PyLong_Type;
+        python_module_ref m = m_context.get_module(m_type->enclosing_module());
+        PyTypeObject*     base = &PyLong_Type;
 
         m_create_data->spec.basicsize = sizeof(PyLongObject);
         m_create_data->spec.flags |=
@@ -217,7 +210,8 @@ namespace mge::python {
 
     void python_type::materialize_complex_class_type() const
     {
-        auto m = m_context.get_module(m_type->module().lock());
+        python_module_ref m = m_context.get_module(m_type->enclosing_module());
+
         if (!m) {
             MGE_THROW(mge::illegal_state)
                 << "Module '" << m_type->module().lock()->name()


### PR DESCRIPTION
- Types in types have not the module field set, but
  only enclosing type.
- Walk up type hierarchy to find toplevel type in
  this case.

Fixes #129