### PR TITLE
Fix configuration logging format string

### DIFF
--- a/src/mge/core/configuration.cpp
+++ b/src/mge/core/configuration.cpp
@@ -205,7 +205,7 @@ namespace mge {
                                          std::string_view value)
     {
         MGE_DEBUG_TRACE(CORE,
-                        "Set parameter value {}.{} to '{}'",
+                        "Set parameter value {}/{} to '{}'",
                         section,
                         name,
                         value);


### PR DESCRIPTION
## Summary
- correct the configuration parameter tracing format string so section and name placeholders are logged separately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69085b394764832a91ce8a3e6e597011