### PR TITLE
Add MGE_WINMAINFUNCTION entry point macro

### DIFF
--- a/src/mge/application/application.hpp
+++ b/src/mge/application/application.hpp
@@ -237,3 +237,14 @@ namespace mge {
     {                                                                          \
         return mge::application::main(argc, argv);                             \
     }
+
+#ifdef MGE_OS_WINDOWS
+#    include <stdlib.h>
+#    include <windows.h>
+#    define MGE_WINMAINFUNCTION                                                \
+        int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)                   \
+        {                                                                      \
+            return mge::application::main(__argc,                              \
+                                          const_cast<const char**>(__argv));   \
+        }
+#endif

--- a/src/mge/application/test/CMakeLists.txt
+++ b/src/mge/application/test/CMakeLists.txt
@@ -21,3 +21,12 @@ MGE_TEST(TARGET test_simple_application
          SOURCES test_simple_application.cpp
          NOMAIN
          LIBRARIES mgeapplication mgecore)
+
+IF(WIN32)
+    MGE_TEST(TARGET test_winmain_application
+             SOURCES test_winmain_application.cpp
+             NOMAIN
+             LIBRARIES mgeapplication mgecore)
+    SET_TARGET_PROPERTIES(test_winmain_application
+                          PROPERTIES WIN32_EXECUTABLE TRUE)
+ENDIF()

--- a/src/mge/application/test/test_winmain_application.cpp
+++ b/src/mge/application/test/test_winmain_application.cpp
@@ -1,0 +1,38 @@
+// mge - Modern Game Engine
+// Copyright (c) 2017-2023 by Alexander Schroeder
+// All rights reserved.
+#include "mge/application/application.hpp"
+#include "mge/core/trace.hpp"
+
+namespace mge {
+    MGE_DEFINE_TRACE(WINMAINAPP);
+
+    class winmainapp : public application
+    {
+    public:
+        winmainapp() = default;
+
+        void setup() override
+        {
+            MGE_DEBUG_TRACE(WINMAINAPP, "Setup winmainapp");
+        }
+
+        void teardown() override
+        {
+            MGE_DEBUG_TRACE(WINMAINAPP, "Teardown winmainapp");
+        }
+
+        void run() override
+        {
+            MGE_DEBUG_TRACE(WINMAINAPP, "Run winmainapp");
+            set_quit();
+            application::run();
+        }
+    };
+
+    MGE_REGISTER_IMPLEMENTATION(winmainapp,
+                                mge::application,
+                                test_winmain_application);
+} // namespace mge
+
+MGE_WINMAINFUNCTION


### PR DESCRIPTION
Add Windows-only `MGE_WINMAINFUNCTION` macro in `application.hpp`, parallel to `MGE_MAINFUNCTION`, providing a `WinMain` entry point that delegates to `mge::application::main()` using `__argc`/`__argv`.

Add `test_winmain_application` test executable built with `WIN32_EXECUTABLE` to validate the WinMain entry path.