### PR TITLE
Add multi-texture binding support

### DIFF
--- a/src/mge/graphics/command_buffer.cpp
+++ b/src/mge/graphics/command_buffer.cpp
@@ -5,6 +5,18 @@
 
 namespace mge {
 
+    void command_buffer::bind_texture(uint32_t      slot,
+                                      mge::texture* tex) noexcept
+    {
+        for (auto& b : m_current_textures) {
+            if (b.slot == slot) {
+                b.texture = tex;
+                return;
+            }
+        }
+        m_current_textures.push_back({slot, tex});
+    }
+
     void command_buffer::draw(const program_handle&       program,
                               const vertex_buffer_handle& vertices,
                               const index_buffer_handle&  indices,
@@ -16,12 +28,12 @@ namespace mge {
         m_index_buffers.push_back(indices);
         m_pipeline_states.push_back(m_current_pipeline_state);
         m_uniform_blocks.push_back(m_current_uniform_block);
-        m_textures.push_back(m_current_texture);
+        m_textures.push_back(m_current_textures);
         m_index_counts.push_back(index_count);
         m_index_offsets.push_back(index_offset);
         m_scissor_rects.push_back(m_current_scissor_rect);
         m_current_uniform_block = nullptr;
-        m_current_texture = nullptr;
+        m_current_textures.clear();
     }
 
     void command_buffer::depth_write(bool enable) noexcept

--- a/src/mge/graphics/command_buffer.hpp
+++ b/src/mge/graphics/command_buffer.hpp
@@ -20,6 +20,17 @@ namespace mge {
     class uniform_block;
 
     /**
+     * @brief Binding of a texture to a slot.
+     */
+    struct texture_binding
+    {
+        uint32_t      slot{0};
+        mge::texture* texture{nullptr};
+    };
+
+    using texture_binding_list = std::vector<texture_binding>;
+
+    /**
      * @brief A command buffer records rendering commands to be
      * submitted to a render context.
      */
@@ -115,15 +126,27 @@ namespace mge {
         /**
          * @brief Bind a texture for subsequent draw commands.
          *
-         * The texture is attached to the next draw() call. After draw(),
-         * the binding is cleared.
+         * The texture is attached to the next draw() call at slot 0.
+         * After draw(), the binding is cleared.
          *
          * @param tex pointer to the texture to bind (nullptr to clear)
          */
         void bind_texture(mge::texture* tex) noexcept
         {
-            m_current_texture = tex;
+            bind_texture(0, tex);
         }
+
+        /**
+         * @brief Bind a texture to a specific slot for subsequent
+         * draw commands.
+         *
+         * The texture is attached to the next draw() call. After
+         * draw(), all texture bindings are cleared.
+         *
+         * @param slot texture slot index
+         * @param tex  pointer to the texture to bind
+         */
+        void bind_texture(uint32_t slot, mge::texture* tex) noexcept;
 
         /**
          * @brief Set the scissor rectangle for subsequent draw commands.
@@ -170,7 +193,7 @@ namespace mge {
          *
          * Calls @c f for each recorded draw command with the program,
          * vertex buffer, index buffer, pipeline state, uniform block,
-         * and texture.
+         * texture bindings, index count, index offset, and scissor.
          *
          * @tparam F callable type
          * @param f callable invoked for each draw command
@@ -218,19 +241,19 @@ namespace mge {
         }
 
     private:
-        pipeline_state m_current_pipeline_state{pipeline_state::DEFAULT};
-        uniform_block* m_current_uniform_block{nullptr};
-        mge::texture*  m_current_texture{nullptr};
-        mge::rectangle m_current_scissor_rect{};
+        pipeline_state       m_current_pipeline_state{pipeline_state::DEFAULT};
+        uniform_block*       m_current_uniform_block{nullptr};
+        texture_binding_list m_current_textures;
+        mge::rectangle       m_current_scissor_rect{};
 
-        std::vector<pipeline_state>       m_pipeline_states;
-        std::vector<program_handle>       m_programs;
-        std::vector<vertex_buffer_handle> m_vertex_buffers;
-        std::vector<index_buffer_handle>  m_index_buffers;
-        std::vector<uniform_block*>       m_uniform_blocks;
-        std::vector<mge::texture*>        m_textures;
-        std::vector<uint32_t>             m_index_counts;
-        std::vector<uint32_t>             m_index_offsets;
-        std::vector<mge::rectangle>       m_scissor_rects;
+        std::vector<pipeline_state>        m_pipeline_states;
+        std::vector<program_handle>        m_programs;
+        std::vector<vertex_buffer_handle>  m_vertex_buffers;
+        std::vector<index_buffer_handle>   m_index_buffers;
+        std::vector<uniform_block*>        m_uniform_blocks;
+        std::vector<texture_binding_list>  m_textures;
+        std::vector<uint32_t>              m_index_counts;
+        std::vector<uint32_t>              m_index_offsets;
+        std::vector<mge::rectangle>        m_scissor_rects;
     };
 } // namespace mge

--- a/src/mge/graphics/pass.cpp
+++ b/src/mge/graphics/pass.cpp
@@ -107,7 +107,7 @@ namespace mge {
                                const index_buffer_handle&  indices,
                                const pipeline_state&       state,
                                mge::uniform_block*         ub,
-                               mge::texture*               tex,
+                               const texture_binding_list& textures,
                                uint32_t                    index_count,
                                uint32_t                    index_offset,
                                const mge::rectangle&       scissor) {
@@ -116,7 +116,7 @@ namespace mge {
                                                        indices,
                                                        state,
                                                        ub,
-                                                       tex,
+                                                       textures,
                                                        index_count,
                                                        index_offset,
                                                        scissor});

--- a/src/mge/graphics/pass.hpp
+++ b/src/mge/graphics/pass.hpp
@@ -254,7 +254,7 @@ namespace mge {
                   cmd.indices,
                   cmd.state,
                   cmd.uniform_block,
-                  cmd.texture,
+                  cmd.textures,
                   cmd.index_count,
                   cmd.index_offset,
                   cmd.scissor);
@@ -280,15 +280,15 @@ namespace mge {
 
         struct draw_command
         {
-            program_handle       program;
-            vertex_buffer_handle vertices;
-            index_buffer_handle  indices;
-            mge::pipeline_state  state;
-            mge::uniform_block*  uniform_block{nullptr};
-            mge::texture*        texture{nullptr};
-            uint32_t             index_count{0};
-            uint32_t             index_offset{0};
-            mge::rectangle       scissor{};
+            program_handle        program;
+            vertex_buffer_handle  vertices;
+            index_buffer_handle   indices;
+            mge::pipeline_state   state;
+            mge::uniform_block*   uniform_block{nullptr};
+            texture_binding_list  textures;
+            uint32_t              index_count{0};
+            uint32_t              index_offset{0};
+            mge::rectangle        scissor{};
         };
 
         std::vector<draw_command> m_draw_commands;

--- a/src/mge/graphics/test/test_command_buffer.cpp
+++ b/src/mge/graphics/test/test_command_buffer.cpp
@@ -50,7 +50,7 @@ TEST(command_buffer, for_each_verifies_single_draw)
                     const mge::index_buffer_handle&  i,
                     const mge::pipeline_state&       state,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& /*scissor*/) {
@@ -82,7 +82,7 @@ TEST(command_buffer, for_each_verifies_multiple_draws)
                     const mge::index_buffer_handle&  i,
                     const mge::pipeline_state&       state,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& /*scissor*/) {
@@ -127,7 +127,7 @@ TEST(command_buffer, for_each_verifies_blend_states)
                     const mge::index_buffer_handle&  i,
                     const mge::pipeline_state&       state,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& /*scissor*/) {
@@ -176,7 +176,7 @@ TEST(command_buffer, depth_write_state)
                     const mge::index_buffer_handle&  i,
                     const mge::pipeline_state&       state,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& /*scissor*/) {
@@ -216,7 +216,7 @@ TEST(command_buffer, depth_test_function_state)
                     const mge::index_buffer_handle&  i,
                     const mge::pipeline_state&       state,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& /*scissor*/) {
@@ -249,7 +249,7 @@ TEST(command_buffer, scissor_default_is_zero_area)
             const mge::index_buffer_handle& /*i*/,
             const mge::pipeline_state& /*state*/,
             mge::uniform_block* /*ub*/,
-            mge::texture* /*tex*/,
+            const mge::texture_binding_list& /*textures*/,
             uint32_t /*index_count*/,
             uint32_t /*index_offset*/,
             const mge::rectangle& scissor) { EXPECT_EQ(scissor.area(), 0u); });
@@ -273,7 +273,7 @@ TEST(command_buffer, set_scissor_persists_across_draws)
                     const mge::index_buffer_handle& /*i*/,
                     const mge::pipeline_state& /*state*/,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& scissor) {
@@ -302,7 +302,7 @@ TEST(command_buffer, clear_scissor_resets)
                     const mge::index_buffer_handle& /*i*/,
                     const mge::pipeline_state& /*state*/,
                     mge::uniform_block* /*ub*/,
-                    mge::texture* /*tex*/,
+                    const mge::texture_binding_list& /*textures*/,
                     uint32_t /*index_count*/,
                     uint32_t /*index_offset*/,
                     const mge::rectangle& scissor) {

--- a/src/modules/directx11/render_context.cpp
+++ b/src/modules/directx11/render_context.cpp
@@ -389,7 +389,7 @@ namespace mge::dx11 {
                                      index_buffer_handle        indices,
                                      const mge::pipeline_state& state,
                                      mge::uniform_block*        ub,
-                                     mge::texture*              tex,
+                                     const mge::texture_binding_list& textures,
                                      uint32_t                   index_count,
                                      uint32_t                   index_offset,
                                      const mge::rectangle&      cmd_scissor) {
@@ -417,7 +417,7 @@ namespace mge::dx11 {
                               vertices.get(),
                               indices.get(),
                               ub,
-                              tex,
+                              textures,
                               index_count,
                               index_offset);
                 if (!state.depth_write()) {
@@ -437,7 +437,7 @@ namespace mge::dx11 {
                                         index_buffer_handle        indices,
                                         const mge::pipeline_state& state,
                                         mge::uniform_block*        ub,
-                                        mge::texture*              tex,
+                                        const mge::texture_binding_list& textures,
                                         uint32_t                   index_count,
                                         uint32_t                   index_offset,
                                         const mge::rectangle& cmd_scissor) {
@@ -475,7 +475,7 @@ namespace mge::dx11 {
                                   vertices.get(),
                                   indices.get(),
                                   ub,
-                                  tex,
+                                  textures,
                                   index_count,
                                   index_offset);
                     if (!state.depth_write()) {
@@ -489,11 +489,11 @@ namespace mge::dx11 {
         }
     }
 
-    void render_context::draw_geometry(mge::program*       program,
-                                       mge::vertex_buffer* vb,
-                                       mge::index_buffer*  ib,
-                                       mge::uniform_block* ub,
-                                       mge::texture*       tex,
+    void render_context::draw_geometry(mge::program*              program,
+                                       mge::vertex_buffer*        vb,
+                                       mge::index_buffer*         ib,
+                                       mge::uniform_block*        ub,
+                                       const mge::texture_binding_list& textures,
                                        uint32_t            index_count,
                                        uint32_t            index_offset)
     {
@@ -573,13 +573,19 @@ namespace mge::dx11 {
                                       nullptr,
                                       0);
 
-        // Bind texture if provided
-        if (tex) {
-            dx11::texture& dx11_tex = static_cast<dx11::texture&>(*tex);
-            ID3D11ShaderResourceView* srv = dx11_tex.shader_resource_view();
-            m_device_context->PSSetShaderResources(0, 1, &srv);
-            ID3D11SamplerState* sampler = dx11_tex.sampler_state();
-            m_device_context->PSSetSamplers(0, 1, &sampler);
+        // Bind textures
+        for (const auto& binding : textures) {
+            if (binding.texture) {
+                dx11::texture& dx11_tex =
+                    static_cast<dx11::texture&>(*binding.texture);
+                ID3D11ShaderResourceView* srv =
+                    dx11_tex.shader_resource_view();
+                m_device_context->PSSetShaderResources(binding.slot,
+                                                       1,
+                                                       &srv);
+                ID3D11SamplerState* sampler = dx11_tex.sampler_state();
+                m_device_context->PSSetSamplers(binding.slot, 1, &sampler);
+            }
         }
 
         UINT element_count =
@@ -588,10 +594,14 @@ namespace mge::dx11 {
                 : static_cast<UINT>(dx11_index_buffer->element_count());
         m_device_context->DrawIndexed(element_count, index_offset, 0);
 
-        // Unbind texture
-        if (tex) {
-            ID3D11ShaderResourceView* null_srv = nullptr;
-            m_device_context->PSSetShaderResources(0, 1, &null_srv);
+        // Unbind textures
+        for (const auto& binding : textures) {
+            if (binding.texture) {
+                ID3D11ShaderResourceView* null_srv = nullptr;
+                m_device_context->PSSetShaderResources(binding.slot,
+                                                       1,
+                                                       &null_srv);
+            }
         }
     }
 

--- a/src/modules/directx11/render_context.hpp
+++ b/src/modules/directx11/render_context.hpp
@@ -72,11 +72,11 @@ namespace mge::dx11 {
         void render(const mge::pass& p) override;
 
     private:
-        void              draw_geometry(mge::program*       program,
-                                        mge::vertex_buffer* vb,
-                                        mge::index_buffer*  ib,
-                                        mge::uniform_block* ub,
-                                        mge::texture*       tex,
+        void              draw_geometry(mge::program*              program,
+                                        mge::vertex_buffer*        vb,
+                                        mge::index_buffer*         ib,
+                                        mge::uniform_block*        ub,
+                                        const mge::texture_binding_list& textures,
                                         uint32_t            index_count = 0,
                                         uint32_t            index_offset = 0);
         void              bind_uniform_block(mge::dx11::program& dx11_program,

--- a/src/modules/directx12/program.cpp
+++ b/src/modules/directx12/program.cpp
@@ -88,46 +88,68 @@ namespace mge::dx12 {
             root_parameters.push_back(param);
         }
 
-        // Descriptor table for texture SRV (t0)
-        D3D12_DESCRIPTOR_RANGE srv_range = {};
-        srv_range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        srv_range.NumDescriptors = 1;
-        srv_range.BaseShaderRegister = 0;
-        srv_range.RegisterSpace = 0;
-        srv_range.OffsetInDescriptorsFromTableStart =
-            D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+        // Descriptor tables for texture SRVs — one root parameter
+        // per sampler binding so each texture slot gets its own
+        // descriptor table entry.
+        std::vector<D3D12_DESCRIPTOR_RANGE> srv_ranges;
+        srv_ranges.reserve(
+            std::max<size_t>(m_sampler_bindings.size(), 1));
 
-        D3D12_ROOT_PARAMETER texture_param = {};
-        texture_param.ParameterType =
-            D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
-        texture_param.DescriptorTable.NumDescriptorRanges = 1;
-        texture_param.DescriptorTable.pDescriptorRanges = &srv_range;
-        texture_param.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-        root_parameters.push_back(texture_param);
+        for (size_t i = 0; i < std::max<size_t>(m_sampler_bindings.size(), 1);
+             ++i) {
+            D3D12_DESCRIPTOR_RANGE range = {};
+            range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+            range.NumDescriptors = 1;
+            range.BaseShaderRegister = static_cast<UINT>(i);
+            range.RegisterSpace = 0;
+            range.OffsetInDescriptorsFromTableStart =
+                D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+            srv_ranges.push_back(range);
+        }
 
-        // Static sampler for s0
-        D3D12_STATIC_SAMPLER_DESC static_sampler = {};
-        static_sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        static_sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        static_sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        static_sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-        static_sampler.MipLODBias = 0;
-        static_sampler.MaxAnisotropy = 0;
-        static_sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-        static_sampler.BorderColor =
-            D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
-        static_sampler.MinLOD = 0.0f;
-        static_sampler.MaxLOD = D3D12_FLOAT32_MAX;
-        static_sampler.ShaderRegister = 0;
-        static_sampler.RegisterSpace = 0;
-        static_sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+        for (size_t i = 0; i < srv_ranges.size(); ++i) {
+            D3D12_ROOT_PARAMETER texture_param = {};
+            texture_param.ParameterType =
+                D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+            texture_param.DescriptorTable.NumDescriptorRanges = 1;
+            texture_param.DescriptorTable.pDescriptorRanges =
+                &srv_ranges[i];
+            texture_param.ShaderVisibility =
+                D3D12_SHADER_VISIBILITY_PIXEL;
+            root_parameters.push_back(texture_param);
+        }
+
+        // Static samplers — one per texture slot
+        std::vector<D3D12_STATIC_SAMPLER_DESC> static_samplers;
+        for (size_t i = 0;
+             i < std::max<size_t>(m_sampler_bindings.size(), 1);
+             ++i) {
+            D3D12_STATIC_SAMPLER_DESC static_sampler = {};
+            static_sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+            static_sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+            static_sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+            static_sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+            static_sampler.MipLODBias = 0;
+            static_sampler.MaxAnisotropy = 0;
+            static_sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+            static_sampler.BorderColor =
+                D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+            static_sampler.MinLOD = 0.0f;
+            static_sampler.MaxLOD = D3D12_FLOAT32_MAX;
+            static_sampler.ShaderRegister = static_cast<UINT>(i);
+            static_sampler.RegisterSpace = 0;
+            static_sampler.ShaderVisibility =
+                D3D12_SHADER_VISIBILITY_PIXEL;
+            static_samplers.push_back(static_sampler);
+        }
 
         D3D12_ROOT_SIGNATURE_DESC desc = {
             .NumParameters = static_cast<UINT>(root_parameters.size()),
             .pParameters =
                 root_parameters.empty() ? nullptr : root_parameters.data(),
-            .NumStaticSamplers = 1,
-            .pStaticSamplers = &static_sampler,
+            .NumStaticSamplers = static_cast<UINT>(static_samplers.size()),
+            .pStaticSamplers =
+                static_samplers.empty() ? nullptr : static_samplers.data(),
             .Flags =
                 D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
         };

--- a/src/modules/directx12/render_context.cpp
+++ b/src/modules/directx12/render_context.cpp
@@ -923,7 +923,7 @@ namespace mge::dx12 {
                                     const mge::index_buffer_handle&  indices,
                                     const mge::pipeline_state&       state,
                                     mge::uniform_block*              ub,
-                                    mge::texture*                    tex,
+                                    const mge::texture_binding_list& textures,
                                     uint32_t              index_count,
                                     uint32_t              index_offset,
                                     const mge::rectangle& cmd_scissor) {
@@ -945,7 +945,7 @@ namespace mge::dx12 {
                               indices.get(),
                               state,
                               ub,
-                              tex,
+                              textures,
                               index_count,
                               index_offset);
             } else {
@@ -960,7 +960,7 @@ namespace mge::dx12 {
                     const mge::index_buffer_handle&  indices,
                     const mge::pipeline_state&       state,
                     mge::uniform_block*              ub,
-                    mge::texture*                    tex,
+                    const mge::texture_binding_list& textures,
                     uint32_t                         index_count,
                     uint32_t                         index_offset,
                     const mge::rectangle&            cmd_scissor) {
@@ -980,20 +980,20 @@ namespace mge::dx12 {
                                   indices.get(),
                                   state,
                                   ub,
-                                  tex,
+                                  textures,
                                   index_count,
                                   index_offset);
                 });
         }
     }
 
-    void render_context::draw_geometry(ID3D12GraphicsCommandList* command_list,
-                                       mge::program*              program,
-                                       mge::vertex_buffer*        vb,
-                                       mge::index_buffer*         ib,
-                                       const mge::pipeline_state& state,
-                                       mge::uniform_block*        ub,
-                                       mge::texture*              tex,
+    void render_context::draw_geometry(ID3D12GraphicsCommandList*        command_list,
+                                       mge::program*                    program,
+                                       mge::vertex_buffer*              vb,
+                                       mge::index_buffer*               ib,
+                                       const mge::pipeline_state&       state,
+                                       mge::uniform_block*              ub,
+                                       const mge::texture_binding_list& textures,
                                        uint32_t                   index_count,
                                        uint32_t                   index_offset)
     {
@@ -1025,16 +1025,21 @@ namespace mge::dx12 {
             bind_uniform_block(command_list, *dx12_program, *ub);
         }
 
-        // Bind texture if provided
-        if (tex) {
+        // Bind textures
+        if (!textures.empty()) {
             ID3D12DescriptorHeap* heaps[] = {m_srv_heap.Get()};
             command_list->SetDescriptorHeaps(1, heaps);
-            auto&    dx12_tex = static_cast<dx12::texture&>(*tex);
-            uint32_t texture_root_index =
+            uint32_t base_texture_root_index =
                 static_cast<uint32_t>(dx12_program->uniform_blocks().size());
-            command_list->SetGraphicsRootDescriptorTable(
-                texture_root_index,
-                dx12_tex.srv_gpu_handle());
+            for (const auto& binding : textures) {
+                if (binding.texture) {
+                    auto& dx12_tex =
+                        static_cast<dx12::texture&>(*binding.texture);
+                    command_list->SetGraphicsRootDescriptorTable(
+                        base_texture_root_index + binding.slot,
+                        dx12_tex.srv_gpu_handle());
+                }
+            }
         }
 
         command_list->IASetPrimitiveTopology(

--- a/src/modules/directx12/render_context.hpp
+++ b/src/modules/directx12/render_context.hpp
@@ -143,13 +143,13 @@ namespace mge::dx12 {
         void create_depth_stencil_views();
         void create_command_lists();
 
-        void draw_geometry(ID3D12GraphicsCommandList* command_list,
-                           mge::program*              program,
-                           mge::vertex_buffer*        vb,
-                           mge::index_buffer*         ib,
-                           const mge::pipeline_state& state,
-                           mge::uniform_block*        ub,
-                           mge::texture*              tex,
+        void draw_geometry(ID3D12GraphicsCommandList*        command_list,
+                           mge::program*                    program,
+                           mge::vertex_buffer*              vb,
+                           mge::index_buffer*               ib,
+                           const mge::pipeline_state&       state,
+                           mge::uniform_block*              ub,
+                           const mge::texture_binding_list& textures,
                            uint32_t                   index_count = 0,
                            uint32_t                   index_offset = 0);
 

--- a/src/modules/opengl/render_context.cpp
+++ b/src/modules/opengl/render_context.cpp
@@ -411,11 +411,11 @@ namespace mge::opengl {
         return m_extent.height;
     }
 
-    void render_context::draw_geometry(mge::program*       program,
-                                       mge::vertex_buffer* vb,
-                                       mge::index_buffer*  ib,
-                                       mge::uniform_block* ub,
-                                       mge::texture*       tex,
+    void render_context::draw_geometry(mge::program*              program,
+                                       mge::vertex_buffer*        vb,
+                                       mge::index_buffer*         ib,
+                                       mge::uniform_block*        ub,
+                                       const mge::texture_binding_list& textures,
                                        uint32_t            index_count,
                                        uint32_t            index_offset)
     {
@@ -437,18 +437,22 @@ namespace mge::opengl {
             bind_uniform_block(gl_program, *ub);
         }
 
-        // Bind texture if provided
-        if (tex) {
-            mge::opengl::texture& gl_tex = static_cast<opengl::texture&>(*tex);
-            glActiveTexture(GL_TEXTURE0);
-            CHECK_OPENGL_ERROR(glActiveTexture);
-            glBindTexture(GL_TEXTURE_2D, gl_tex.texture_name());
-            CHECK_OPENGL_ERROR(glBindTexture);
-            // Set all sampler uniforms to texture unit 0
-            for (const auto& sampler : gl_program.sampler_bindings()) {
-                glUniform1i(static_cast<GLint>(sampler.binding), 0);
-                CHECK_OPENGL_ERROR(glUniform1i);
+        // Bind textures
+        for (const auto& binding : textures) {
+            if (binding.texture) {
+                mge::opengl::texture& gl_tex =
+                    static_cast<opengl::texture&>(*binding.texture);
+                glActiveTexture(GL_TEXTURE0 + binding.slot);
+                CHECK_OPENGL_ERROR(glActiveTexture);
+                glBindTexture(GL_TEXTURE_2D, gl_tex.texture_name());
+                CHECK_OPENGL_ERROR(glBindTexture);
             }
+        }
+        // Set sampler uniforms to their respective texture units
+        for (const auto& sampler : gl_program.sampler_bindings()) {
+            glUniform1i(static_cast<GLint>(sampler.binding),
+                        static_cast<GLint>(sampler.binding));
+            CHECK_OPENGL_ERROR(glUniform1i);
         }
 
         if (!vb) {
@@ -502,9 +506,12 @@ namespace mge::opengl {
         CHECK_OPENGL_ERROR(glDrawElements);
         glBindVertexArray(0);
         CHECK_OPENGL_ERROR(glBindVertexArray(0));
-        if (tex) {
-            glBindTexture(GL_TEXTURE_2D, 0);
-            CHECK_OPENGL_ERROR(glBindTexture(0));
+        // Unbind textures
+        for (const auto& binding : textures) {
+            if (binding.texture) {
+                glActiveTexture(GL_TEXTURE0 + binding.slot);
+                glBindTexture(GL_TEXTURE_2D, 0);
+            }
         }
         glUseProgram(0);
         CHECK_OPENGL_ERROR(glUseProgram(0));
@@ -630,7 +637,7 @@ namespace mge::opengl {
                 const index_buffer_handle&  indices,
                 const mge::pipeline_state&  state,
                 mge::uniform_block*         ub,
-                mge::texture*               tex,
+                const mge::texture_binding_list& textures,
                 uint32_t                    index_count,
                 uint32_t                    index_offset,
                 const mge::rectangle&       cmd_scissor) {
@@ -674,7 +681,7 @@ namespace mge::opengl {
                                   vertices.get(),
                                   indices.get(),
                                   ub,
-                                  tex,
+                                  textures,
                                   index_count,
                                   index_offset);
                     if (conservative_raster_enabled) {
@@ -702,7 +709,7 @@ namespace mge::opengl {
                                         const index_buffer_handle&  indices,
                                         const mge::pipeline_state&  state,
                                         mge::uniform_block*         ub,
-                                        mge::texture*               tex,
+                                        const mge::texture_binding_list& textures,
                                         uint32_t                    index_count,
                                         uint32_t              index_offset,
                                         const mge::rectangle& cmd_scissor) {
@@ -773,7 +780,7 @@ namespace mge::opengl {
                                   vertices.get(),
                                   indices.get(),
                                   ub,
-                                  tex,
+                                  textures,
                                   index_count,
                                   index_offset);
                     if (conservative_raster_enabled) {

--- a/src/modules/opengl/render_context.hpp
+++ b/src/modules/opengl/render_context.hpp
@@ -70,11 +70,11 @@ namespace mge {
             GLuint create_vao(mge::opengl::vertex_buffer* vb,
                               mge::opengl::index_buffer*  ib);
 
-            void draw_geometry(mge::program*       program,
-                               mge::vertex_buffer* vb,
-                               mge::index_buffer*  ib,
-                               mge::uniform_block* ub,
-                               mge::texture*       tex,
+            void draw_geometry(mge::program*              program,
+                               mge::vertex_buffer*        vb,
+                               mge::index_buffer*         ib,
+                               mge::uniform_block*        ub,
+                               const mge::texture_binding_list& textures,
                                uint32_t            index_count = 0,
                                uint32_t            index_offset = 0);
 
@@ -94,11 +94,11 @@ namespace mge {
             GLuint create_vao(mge::opengl::vertex_buffer* vb,
                               mge::opengl::index_buffer*  ib);
 
-            void draw_geometry(mge::program*       program,
-                               mge::vertex_buffer* vb,
-                               mge::index_buffer*  ib,
-                               mge::uniform_block* ub,
-                               mge::texture*       tex,
+            void draw_geometry(mge::program*              program,
+                               mge::vertex_buffer*        vb,
+                               mge::index_buffer*         ib,
+                               mge::uniform_block*        ub,
+                               const mge::texture_binding_list& textures,
                                uint32_t            index_count = 0,
                                uint32_t            index_offset = 0);
 

--- a/src/modules/vulkan/render_context.cpp
+++ b/src/modules/vulkan/render_context.cpp
@@ -1345,7 +1345,7 @@ namespace mge::vulkan {
 
         // Get or create descriptor set
         auto desc_key = std::make_tuple(&ub,
-                                        static_cast<mge::texture*>(nullptr),
+                                        std::vector<mge::texture*>{},
                                         vk_program.descriptor_set_layout());
         VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
         auto            desc_it = m_descriptor_sets.find(desc_key);
@@ -1409,7 +1409,12 @@ namespace mge::vulkan {
                                       mge::texture*         tex,
                                       mge::uniform_block*   ub)
     {
-        VkDescriptorSet descriptor_set = prepare_texture(vk_program, tex, ub);
+        mge::texture_binding_list textures;
+        if (tex) {
+            textures.push_back({0, tex});
+        }
+        VkDescriptorSet descriptor_set =
+            prepare_texture(vk_program, textures, ub);
         if (descriptor_set != VK_NULL_HANDLE) {
             vkCmdBindDescriptorSets(command_buffer,
                                     VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -1423,15 +1428,13 @@ namespace mge::vulkan {
     }
 
     VkDescriptorSet
-    render_context::prepare_texture(mge::vulkan::program& vk_program,
-                                    mge::texture*         tex,
-                                    mge::uniform_block*   ub)
+    render_context::prepare_texture(mge::vulkan::program&            vk_program,
+                                    const mge::texture_binding_list& textures,
+                                    mge::uniform_block*              ub)
     {
-        if (!tex) {
+        if (textures.empty()) {
             return VK_NULL_HANDLE;
         }
-
-        auto* vk_tex = static_cast<mge::vulkan::texture*>(tex);
 
         const auto& sampler_bindings = vk_program.sampler_bindings();
         if (sampler_bindings.empty()) {
@@ -1443,13 +1446,18 @@ namespace mge::vulkan {
             return VK_NULL_HANDLE;
         }
 
-        // Reuse the descriptor set from prepare_uniform_block if available,
-        // so both UBO and sampler bindings are on the same set.
-        // Key includes texture pointer so each ub+tex pair gets its own set.
-        auto desc_key =
-            std::make_tuple(ub ? ub : static_cast<mge::uniform_block*>(nullptr),
-                            static_cast<mge::texture*>(tex),
-                            layout);
+        // Build texture pointer vector for cache key
+        // (sorted by slot for consistent key ordering)
+        std::vector<mge::texture*> tex_ptrs;
+        tex_ptrs.reserve(textures.size());
+        for (const auto& b : textures) {
+            tex_ptrs.push_back(b.texture);
+        }
+
+        auto desc_key = std::make_tuple(
+            ub ? ub : static_cast<mge::uniform_block*>(nullptr),
+            tex_ptrs,
+            layout);
 
         VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
         auto            desc_it = m_descriptor_sets.find(desc_key);
@@ -1457,16 +1465,15 @@ namespace mge::vulkan {
         if (desc_it != m_descriptor_sets.end()) {
             descriptor_set = desc_it->second;
         } else {
-            // Check if there's already a set with UBO written (no texture)
-            // and copy from it, or allocate fresh
+            // Check if there's already a set with UBO written (no textures)
             auto ub_only_key = std::make_tuple(
                 ub ? ub : static_cast<mge::uniform_block*>(nullptr),
-                static_cast<mge::texture*>(nullptr),
+                std::vector<mge::texture*>{},
                 layout);
             auto ub_it = m_descriptor_sets.find(ub_only_key);
 
             if (ub && ub_it != m_descriptor_sets.end()) {
-                // Need a new set with both UBO and texture written
+                // Need a new set with both UBO and textures written
                 VkDescriptorSetAllocateInfo alloc_info = {};
                 alloc_info.sType =
                     VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -1525,8 +1532,23 @@ namespace mge::vulkan {
                 }
             }
 
-            // Write texture binding
+            // Write texture bindings — match each sampler binding to
+            // the texture bound at the corresponding slot
             for (const auto& sb : sampler_bindings) {
+                mge::texture* matched_tex = nullptr;
+                for (const auto& binding : textures) {
+                    if (binding.slot == sb.binding) {
+                        matched_tex = binding.texture;
+                        break;
+                    }
+                }
+                if (!matched_tex) {
+                    continue;
+                }
+
+                auto* vk_tex =
+                    static_cast<mge::vulkan::texture*>(matched_tex);
+
                 VkDescriptorImageInfo image_info = {};
                 image_info.imageLayout =
                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -1556,13 +1578,13 @@ namespace mge::vulkan {
         return descriptor_set;
     }
 
-    void render_context::draw_geometry(VkCommandBuffer     command_buffer,
-                                       mge::program*       program,
-                                       mge::vertex_buffer* vb,
-                                       mge::index_buffer*  ib,
+    void render_context::draw_geometry(VkCommandBuffer            command_buffer,
+                                       mge::program*              program,
+                                       mge::vertex_buffer*        vb,
+                                       mge::index_buffer*         ib,
                                        const mge::pipeline_state& state,
                                        mge::uniform_block*        ub,
-                                       mge::texture*              tex,
+                                       const mge::texture_binding_list& textures,
                                        uint32_t                   index_count,
                                        uint32_t                   index_offset)
     {
@@ -1579,15 +1601,16 @@ namespace mge::vulkan {
                           VK_PIPELINE_BIND_POINT_GRAPHICS,
                           pipeline);
 
-        // Bind uniform block and texture together to avoid
+        // Bind uniform block and textures together to avoid
         // updating a descriptor set that is already bound
-        if (ub || tex) {
+        if (ub || !textures.empty()) {
             VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
             if (ub) {
                 descriptor_set = prepare_uniform_block(*vk_program, *ub);
             }
-            if (tex) {
-                descriptor_set = prepare_texture(*vk_program, tex, ub);
+            if (!textures.empty()) {
+                descriptor_set =
+                    prepare_texture(*vk_program, textures, ub);
             }
             if (descriptor_set != VK_NULL_HANDLE) {
                 vkCmdBindDescriptorSets(command_buffer,
@@ -1724,7 +1747,7 @@ namespace mge::vulkan {
                 const index_buffer_handle&  index_buffer,
                 const mge::pipeline_state&  state,
                 mge::uniform_block*         ub,
-                mge::texture*               tex,
+                const mge::texture_binding_list& textures,
                 uint32_t                    index_count,
                 uint32_t                    index_offset,
                 const mge::rectangle&       cmd_scissor) {
@@ -1749,7 +1772,7 @@ namespace mge::vulkan {
                                   index_buffer.get(),
                                   state,
                                   ub,
-                                  tex,
+                                  textures,
                                   index_count,
                                   index_offset);
                 } else {
@@ -1764,7 +1787,7 @@ namespace mge::vulkan {
                     const index_buffer_handle&  index_buffer,
                     const mge::pipeline_state&  state,
                     mge::uniform_block*         ub,
-                    mge::texture*               tex,
+                    const mge::texture_binding_list& textures,
                     uint32_t                    index_count,
                     uint32_t                    index_offset,
                     const mge::rectangle&       cmd_scissor) {
@@ -1790,7 +1813,7 @@ namespace mge::vulkan {
                                   index_buffer.get(),
                                   state,
                                   ub,
-                                  tex,
+                                  textures,
                                   index_count,
                                   index_offset);
                 });

--- a/src/modules/vulkan/render_context.hpp
+++ b/src/modules/vulkan/render_context.hpp
@@ -121,7 +121,7 @@ namespace mge::vulkan {
                            mge::index_buffer*         ib,
                            const mge::pipeline_state& state,
                            mge::uniform_block*        ub,
-                           mge::texture*              tex,
+                           const mge::texture_binding_list& textures,
                            uint32_t                   index_count = 0,
                            uint32_t                   index_offset = 0);
 
@@ -138,7 +138,7 @@ namespace mge::vulkan {
                                               mge::uniform_block&   ub);
 
         VkDescriptorSet prepare_texture(mge::vulkan::program& vk_program,
-                                        mge::texture*         tex,
+                                        const mge::texture_binding_list& textures,
                                         mge::uniform_block*   ub);
 
     private:
@@ -234,8 +234,10 @@ namespace mge::vulkan {
         };
         std::map<mge::uniform_block*, uniform_buffer_data> m_uniform_buffers;
         VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
-        using descriptor_set_key = std::
-            tuple<mge::uniform_block*, mge::texture*, VkDescriptorSetLayout>;
+        using descriptor_set_key =
+            std::tuple<mge::uniform_block*,
+                       std::vector<mge::texture*>,
+                       VkDescriptorSetLayout>;
         std::map<descriptor_set_key, VkDescriptorSet> m_descriptor_sets;
     };
 } // namespace mge::vulkan


### PR DESCRIPTION
Extend the graphics abstraction and all four backends to support binding multiple textures per draw call.

## Changes

**Abstraction layer** (`command_buffer`, `pass`):
- Add `texture_binding` struct (slot + texture pointer) and `texture_binding_list` type
- Add `bind_texture(slot, texture)` overload; original single-texture API delegates to slot 0
- `draw_command` stores `texture_binding_list` instead of single `texture*`

**DirectX 11**: Loop over bindings, set SRV and sampler per slot via `PSSetShaderResources`/`PSSetSamplers`

**DirectX 12**: Create per-sampler SRV descriptor ranges and static samplers in root signature; bind descriptor table per texture slot

**OpenGL**: Activate texture unit per slot (`GL_TEXTURE0 + slot`), set sampler uniforms to their binding unit

**Vulkan**: Update `descriptor_set_key` to use `vector<texture*>` for cache lookups; match textures to sampler bindings by slot; write descriptors per matched texture